### PR TITLE
spec: add centos-release, drop %{centos_rel} refs

### DIFF
--- a/centos-devel-atomic-host-release.spec
+++ b/centos-devel-atomic-host-release.spec
@@ -14,7 +14,8 @@
 
 Name:           centos-devel-atomic-host-release
 Version:        %{base_release_version}
-Release:        %{centos_rel}%{?dist}.2.10
+# mostly academic; this will get clobbered by rdgo anyway
+Release:        1-%{?dist}.devel
 Summary:        %{product_family} release file
 Group:          System Environment/Base
 License:        GPLv2
@@ -39,9 +40,10 @@ mkdir -p %{buildroot}/etc
 mkdir -p %{buildroot}/usr/lib/
 
 # create /etc/system-release and /etc/redhat-release
-echo "%{product_family} release %{full_release_version}.%{centos_rel} (%{release_name}) " > %{buildroot}/usr/lib/centos-release-devel
-ln -s ../usr/lib/centos-release-devel %{buildroot}/etc/system-release
-ln -s ../usr/lib/centos-release-devel %{buildroot}/etc/redhat-release
+echo "%{product_family} release %{full_release_version} (%{release_name}) " > %{buildroot}/usr/lib/centos-release-devel
+ln -s ../usr/lib/centos-release-devel %{buildroot}/etc/centos-release
+ln -s centos-release %{buildroot}/etc/system-release
+ln -s centos-release %{buildroot}/etc/redhat-release
 
 # create /etc/os-release
 cat << EOF >>%{buildroot}/usr/lib/os-release
@@ -106,6 +108,7 @@ install -m 0644 90-default.preset %{buildroot}%{_prefix}/lib/systemd/system-pres
 
 %files
 %defattr(0644,root,root,0755)
+/etc/centos-release
 /etc/redhat-release
 /etc/system-release
 /etc/os-release


### PR DESCRIPTION
I might be missing part of the picture here, but unlike its downstream
equivalent, there's no point in using a `%{centos_rel}` macro since
AFAICT this package is only used by rdgo. This was causing
`%{centos_rel}` to literally be in the various release files.

We also mimic the downstream version by adding a `/etc/centos-release`
and symlinking `redhat-release` and `system-release` to that.