### PR TITLE
spec: Bump fictional upstream release version to 7.5.0.1

### DIFF
--- a/centos-devel-atomic-host-release.spec
+++ b/centos-devel-atomic-host-release.spec
@@ -8,7 +8,7 @@
 %define dist_release_version 7
 # Irritatingly systemd depends on system-release >= 7.2 so
 # we need to synthesize that.
-%define upstream_release_version 7.2
+%define upstream_release_version 7.5.0.1
 #define beta Beta
 %define dist .el%{dist_release_version}.centos
 


### PR DESCRIPTION
The `initscripts` package has:

```
Conflicts: redhat-release < 7.5-0.11
```

So this causes treecompose failures[1] because we're not providing a
high enough version. Let's fix this for now by just bumping the upstream
release version. I added the `.0.1` to make sure we definitely sort
higher than `7.5` regardless of the `Release` tag, which gets generated
by rdgo.

[1] https://github.com/CentOS/sig-atomic-buildscripts/issues/328